### PR TITLE
rk3128: wrong /sys paths

### DIFF
--- a/board/batocera/rockchip/ps5000/fsoverlay/usr/bin/cputemp
+++ b/board/batocera/rockchip/ps5000/fsoverlay/usr/bin/cputemp
@@ -4,5 +4,5 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
-TEMP="$(cat /sys/class/thermal/thermal_zone1/temp)"
+TEMP="$(cat /sys/class/thermal/thermal_zone0/temp)"
 echo "$(( $TEMP / 1000 )) C"

--- a/board/batocera/rockchip/ps5000/fsoverlay/usr/bin/gputemp
+++ b/board/batocera/rockchip/ps5000/fsoverlay/usr/bin/gputemp
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
-# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
-
-TEMP="$(cat /sys/class/thermal/thermal_zone2/temp)"
-echo "$(( $TEMP / 1000 )) C"

--- a/board/batocera/rockchip/ps5000/fsoverlay/usr/share/batocera/configgen/scripts/governor.sh
+++ b/board/batocera/rockchip/ps5000/fsoverlay/usr/share/batocera/configgen/scripts/governor.sh
@@ -4,12 +4,12 @@ EVENT=$1
 
 case "${EVENT}" in
     gameStart)
-	echo performance > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+	echo performance > /sys/devices/platform/10091000.gpu/devfreq/10091000.gpu/governor
 	echo performance > /sys/devices/platform/dmc/devfreq/dmc/governor
 	echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
     ;;
     gameStop)
-	echo simple_ondemand > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+	echo simple_ondemand > /sys/devices/platform/10091000.gpu/devfreq/10091000.gpu/governor
 	echo dmc_ondemand    > /sys/devices/platform/dmc/devfreq/dmc/governor
 	echo performance     > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
     ;;


### PR DESCRIPTION
Changes in /sys paths for rk3128.

- /sys/*gpu* is mapped @10091000
- cpu temperature is thermal_zone0
- gpu temperature does not exists

Signed-off-by: Martin Cerveny <m.cerveny@computer.org>